### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
         
     - name: Build the hello-world Docker image
       run: |
-        docker build . --tag ghrc.io/hnolas/nasawebapp-final
-        docker run ghrc.io/hnolas/nasawebapp-final
-        docker push ghrc.io/hnolas/nasawebapp-final
+        docker build . --tag ghcr.io/hnolas/nasawebapp-final
+        docker run ghcr.io/hnolas/nasawebapp-final
+        docker push ghcr.io/hnolas/nasawebapp-final


### PR DESCRIPTION
Hi `hnolas/docker_nasa_node_webapp`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.